### PR TITLE
Code size reduction via AST rewrite

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,11 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest
+          pytest --cov=. --cov-report=xml
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,7 @@ jobs:
           python-version: "3.10"
       - name: Install dependencies
         run: |
-          pip install -e .
-          pip install pytest
+          pip install -e ".[dev]"
 
       - name: Test with pytest
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 *.zip
 _build/
 dist/
+.hypothesis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+ - Add `pyidide minify` command to minify the Python packages with AST rewrites by,
+   removing comments and docstrings
+   [#23](https://github.com/pyodide/pyodide-pack/pull/23)
+
 ## [0.2.0] - 2022-09-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ wget https://cdn.jsdelivr.net/pyodide/v0.20.0/full/packages.json -O node_modules
 
 For Python wheel minification via AST rewrites, run,
 ```
-pyodide minify <path_to_wheel>.whl
+pyodide minify <path_to_dir_with_py_files>
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![PyPI Latest Release](https://img.shields.io/pypi/v/pyodide-pack.svg)](https://pypi.org/project/pyodide-pack/)
 [![GHA CI](https://github.com/rth/pyodide-pack/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/rth/pyodide-pack/actions/workflows/main.yml)
+[![codecov](https://codecov.io/github/pyodide/pyodide-pack/branch/main/graph/badge.svg?token=2BBYXLX6AE)](https://codecov.io/github/pyodide/pyodide-pack)
 
 Python package bundler and minifier for the web
 
@@ -14,16 +15,28 @@ Each of these approaches have different tradeoffs, and can be used separately or
 
 ## Install
 
-Pyodide-pack requires Python 3.10+ as well as NodeJS,
+Pyodide-pack requires Python 3.10+ and can be installed via pip:
+
+```
+pip install pyodide-pack
+```
+
+(optionally) For elimation of unused modules via runtime detection, run NodeJS  needs to be installed,
+as well,
 
 ```bash
-pip install pyodide-pack
 npm install pyodide@0.20.1-alpha.2
 # A hack due to the npm package having issues
 wget https://cdn.jsdelivr.net/pyodide/v0.20.0/full/packages.json -O node_modules/pyodide/packages.json
 ```
 
 ## Usage
+
+For Python wheel minification via AST rewrites, run,
+```
+pyodide minify <path_to_wheel>.whl
+```
+
 
 See the documentation at [pyodide-pack.pyodide.org](https://pyodide-pack.pyodide.org).
 

--- a/docs/ast-rewrite.md
+++ b/docs/ast-rewrite.md
@@ -10,5 +10,5 @@ In this section we apply Abstract Syntax Tree (AST) rewrites to the package sour
 
 To apply rewrites on one or multiple wheels, run,
 ```bash
-pyodide minify <path.whl>
+pyodide minify <path_to_dir_with_py_files>
 ```

--- a/docs/ast-rewrite.md
+++ b/docs/ast-rewrite.md
@@ -1,0 +1,14 @@
+(=ast-rewrite)
+
+# Abstract Syntax Tree (AST) Rewrite
+
+In this section we apply Abstract Syntax Tree (AST) rewrites to the package source code. These include,
+
+ - removal of comments
+ - removal of function and class docstrings
+ - removal of module docstrings
+
+To apply rewrites on one or multiple wheels, run,
+```bash
+pyodide minify <path.whl>
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,3 +9,9 @@ This page documents the pyodide-pack Command Line Interface (CLI) interface,
    :prog: pyodide pack
    :nested: full
 ```
+
+```{eval-rst}
+.. click:: pyodide_pack.ast_rewrite:typer_click_object
+   :prog: pyodide minify
+   :nested: full
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,5 +20,6 @@ Each of these approaches have different tradeoffs, and can be used separately or
    :maxdepth: 1
    :caption: Contents:
 
+   ast-rewrite.md
    module-elimination-at-runtime.md
    cli.md

--- a/pyodide_pack/ast_rewrite.py
+++ b/pyodide_pack/ast_rewrite.py
@@ -1,0 +1,92 @@
+import ast
+import shutil
+import sys
+import zipfile
+from pathlib import Path
+from time import perf_counter
+
+import typer
+
+
+class _StripDocstringsTransformer(ast.NodeTransformer):
+    """Strip docstring in an AST tree.
+
+    AST parsing also strips comments.
+    """
+
+    def visit_FunctionDef(self, node):
+        """Remove the docstring from the function definition"""
+        if ast.get_docstring(node, clean=False) is not None:
+            del node.body[0]
+        # Continue processing the function's body
+        self.generic_visit(node)
+        return node
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+    visit_ClassDef = visit_FunctionDef
+
+
+def _strip_module_docstring(tree: ast.Module) -> ast.Module:
+    """Remove docstring from module.
+
+    If the first statement is an expression with a string value, remove it.
+    """
+    if (
+        tree.body
+        and isinstance(expr := tree.body[0], ast.Expr)
+        and isinstance(expr.value, ast.Str | ast.Constant)
+        and isinstance(expr.value.value, str)
+    ):
+        tree.body.pop(0)
+    return tree
+
+
+def main(
+    input_dir: Path = typer.Argument(..., help="Path to the folder to compress"),
+    strip_docstrings: bool = typer.Option(False, help="Strip docstrings"),
+) -> None:
+    """Minify a folder of Python files."""
+    output_dirname = input_dir.name + "_stripped"
+    if strip_docstrings:
+        output_dirname += "_no_docstrings"
+    output_dir = input_dir.parent / output_dirname
+    shutil.rmtree(output_dir, ignore_errors=True)
+    shutil.copytree(input_dir, output_dir)
+    t0 = perf_counter()
+    n_processed = 0
+    for file in output_dir.glob("**/*.py"):
+        if not file.is_file():
+            continue
+
+        try:
+            code = file.read_text()
+        except UnicodeDecodeError:
+            continue
+
+        try:
+            tree = ast.parse(code)
+        except SyntaxError:
+            continue
+        if strip_docstrings:
+            tree = _strip_module_docstring(tree)
+            tree = _StripDocstringsTransformer().visit(tree)
+
+        uncommented_code = ast.unparse(tree)
+        file.write_text(uncommented_code)
+        n_processed += 1
+
+    typer.echo(f"Processed {n_processed} files in {perf_counter() - t0:.2f} seconds")
+
+    zip_path = output_dir.parent / (output_dir.name + ".zip")
+    with zipfile.ZipFile(zip_path, "w", compression=0) as fh:
+        for file in output_dir.glob("**/*"):
+            if not file.is_file():
+                continue
+            fh.write(file, file.relative_to(output_dir))
+    typer.echo(f"Created zip file at {zip_path}")
+
+
+if "sphinx" in sys.modules and __name__ != "__main__":
+    app = typer.Typer()
+    app.command()(main)
+    typer_click_object = typer.main.get_command(app)

--- a/pyodide_pack/ast_rewrite.py
+++ b/pyodide_pack/ast_rewrite.py
@@ -45,7 +45,10 @@ def main(
     input_dir: Path = typer.Argument(..., help="Path to the folder to compress"),
     strip_docstrings: bool = typer.Option(False, help="Strip docstrings"),
 ) -> None:
-    """Minify a folder of Python files."""
+    """Minify a folder of Python files.
+
+    Note: this API will change before the next release
+    """
     output_dirname = input_dir.name + "_stripped"
     if strip_docstrings:
         output_dirname += "_no_docstrings"

--- a/pyodide_pack/testing.py
+++ b/pyodide_pack/testing.py
@@ -10,6 +10,9 @@ def _get_stdlib_module_paths() -> list[Path]:
     base_dir = Path(os.__file__).parent
     res = []
     for path in base_dir.glob("**/*.py"):
+        if "test" in str(path):
+            # There are test files in the standard library, skip them
+            continue
         if path.parts[-4:-1] == ("lib2to3", "tests", "data"):
             # There are files in this folder with either Python2 or bad encoding, skip them
             continue

--- a/pyodide_pack/testing.py
+++ b/pyodide_pack/testing.py
@@ -1,0 +1,17 @@
+import os
+from pathlib import Path
+
+
+def _get_stdlib_module_paths() -> list[Path]:
+    """Return a list of paths to the standard library modules.
+
+    This is mainly used for testing purposes.
+    """
+    base_dir = Path(os.__file__).parent
+    res = []
+    for path in base_dir.glob("**/*.py"):
+        if path.parts[-4:-1] == ("lib2to3", "tests", "data"):
+            # There are files in this folder with either Python2 or bad encoding, skip them
+            continue
+        res.append(path)
+    return res

--- a/pyodide_pack/tests/conftest.py
+++ b/pyodide_pack/tests/conftest.py
@@ -1,0 +1,22 @@
+import sys
+import zipfile
+from io import BytesIO
+
+import pytest
+
+from pyodide_pack.testing import _get_stdlib_module_paths
+
+
+@pytest.fixture(scope="session")
+def example_zipfile_xml() -> bytes:
+    """Example zip file (as bytes) containing the xml related modules."""
+    stream = BytesIO()
+    with zipfile.ZipFile(stream, "w") as zf:
+        for path in _get_stdlib_module_paths():
+            if "xml" not in str(path):
+                continue
+            zf.write(path, path.relative_to(sys.prefix))
+
+    stream.seek(0)
+
+    return stream.read()

--- a/pyodide_pack/tests/test_ast_rewrite.py
+++ b/pyodide_pack/tests/test_ast_rewrite.py
@@ -2,7 +2,7 @@ import ast
 from textwrap import dedent
 
 import hypothesis.strategies as st
-from hypothesis import given
+from hypothesis import given, settings
 
 from pyodide_pack.ast_rewrite import (
     _strip_module_docstring,
@@ -104,6 +104,7 @@ def test_strip_module_docstrings():
     )
 
 
+@settings(deadline=300)
 @given(st.sampled_from(_get_stdlib_module_paths()))
 def test_process_all_stdlib(path):
     """Check that we can process all of the stdlib without crashing."""

--- a/pyodide_pack/tests/test_ast_rewrite.py
+++ b/pyodide_pack/tests/test_ast_rewrite.py
@@ -1,4 +1,5 @@
 import ast
+from pathlib import Path
 from textwrap import dedent
 
 import hypothesis.strategies as st
@@ -114,3 +115,19 @@ def test_process_all_stdlib(path):
     tree = _strip_module_docstring(tree)
     tree = _StripDocstringsTransformer().visit(tree)
     ast.unparse(tree)
+
+
+def test_cli_minify(tmp_path):
+    import pathlib
+
+    from pyodide_pack.ast_rewrite import main
+
+    input_dir = tmp_path / "input_dir"
+    input_dir.mkdir()
+    (input_dir / "pathlib.py").write_text(Path(pathlib.__file__).read_text())
+
+    main(input_dir, strip_docstrings=False)
+    output_path = tmp_path / "input_dir_stripped.zip"
+    assert output_path.exists()
+    # There is at least a 10% size reduction, though this test and API needs to be rewritten
+    assert (input_dir / "pathlib.py").stat().st_size > 1.1 * output_path.stat().st_size

--- a/pyodide_pack/tests/test_ast_rewrite.py
+++ b/pyodide_pack/tests/test_ast_rewrite.py
@@ -1,0 +1,115 @@
+import ast
+from textwrap import dedent
+
+import hypothesis.strategies as st
+from hypothesis import given
+
+from pyodide_pack.ast_rewrite import (
+    _strip_module_docstring,
+    _StripDocstringsTransformer,
+)
+from pyodide_pack.testing import _get_stdlib_module_paths
+
+
+def test_strip_docstrings_function():
+    src_code = '''
+        def foo():
+            """This is a docstring"""
+            return 1
+        '''
+    tree = ast.parse(dedent(src_code))
+    tree = _StripDocstringsTransformer().visit(tree)
+    assert (
+        ast.unparse(tree)
+        == dedent(
+            """
+        def foo():
+            return 1"""
+        ).strip("\n")
+    )
+
+
+def test_strip_docstrings_nested_functions():
+    src_code = '''
+        def foo():
+            """This is a docstring"""
+            def bar():
+                """This is a docstring"""
+                return 2
+            return bar
+        '''
+    tree = ast.parse(dedent(src_code))
+    tree = _StripDocstringsTransformer().visit(tree)
+    assert (
+        ast.unparse(tree)
+        == dedent(
+            """
+        def foo():
+
+            def bar():
+                return 2
+            return bar
+        """
+        ).strip("\n")
+    )
+
+
+def test_strip_docstrings_class():
+    src_code = '''
+        class A:
+            """
+            1
+            2
+            3
+            """
+            def foo(self):
+                """This is a docstring"""
+                return 2
+            def bar(self):
+                """This is a docstring"""
+                return 1
+        '''
+    tree = ast.parse(dedent(src_code))
+    tree = _StripDocstringsTransformer().visit(tree)
+    assert (
+        ast.unparse(tree)
+        == dedent(
+            """
+        class A:
+
+            def foo(self):
+                return 2
+
+            def bar(self):
+                return 1
+        """
+        ).strip("\n")
+    )
+
+
+def test_strip_module_docstrings():
+    src_code = '''
+        """This is a docstring"""
+        a = 1
+        '''
+    tree = ast.parse(dedent(src_code))
+    tree = _strip_module_docstring(tree)
+    assert (
+        ast.unparse(tree)
+        == dedent(
+            """
+        a = 1
+        """
+        ).strip("\n")
+    )
+
+
+@given(st.sampled_from(_get_stdlib_module_paths()))
+def test_process_all_stdlib(path):
+    """Check that we can process all of the stdlib without crashing."""
+    code = path.read_text()
+
+    tree = ast.parse(code)
+    tree = _strip_module_docstring(tree)
+    tree = _StripDocstringsTransformer().visit(tree)
+    ast.unparse(tree)

--- a/pyodide_pack/tests/test_testing.py
+++ b/pyodide_pack/tests/test_testing.py
@@ -1,0 +1,7 @@
+from pyodide_pack.testing import _get_stdlib_module_paths
+
+
+def test_get_stdlib_module_paths():
+    paths = _get_stdlib_module_paths()
+    assert len(paths) > 2500
+    assert all(p.suffix == ".py" for p in paths)

--- a/pyodide_pack/tests/test_testing.py
+++ b/pyodide_pack/tests/test_testing.py
@@ -3,5 +3,5 @@ from pyodide_pack.testing import _get_stdlib_module_paths
 
 def test_get_stdlib_module_paths():
     paths = _get_stdlib_module_paths()
-    assert len(paths) > 2500
+    assert len(paths) > 2000
     assert all(p.suffix == ".py" for p in paths)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ minify = "pyodide_pack.ast_rewrite:main"
 [project.optional-dependencies]
 dev = [
     "pytest",
+    "pytest-cov",
     "hypothesis",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,16 @@ content-type = "text/markdown"
 Homepage = "https://github.com/rth/pyodide-bundler"
 "Bug Tracker" = "https://github.com/rth/pyodide-bundler"
 
-[project.entry-points]
-"pyodide.cli" = {pack = "pyodide_pack.cli:main"}
+[project.entry-points."pyodide.cli"]
+
+pack = "pyodide_pack.cli:main"
+minify = "pyodide_pack.ast_rewrite:main"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "hypothesis",
+]
 
 [tool.setuptools]
 package-dir = {"" = "."}


### PR DESCRIPTION
This aims to apply light and reliable code size reduction via AST rewrite of the package source code.

In particular, this implements,
 - stripping of comments (happens for any kind of AST rewrite)
 - removing of doctests from functions and classes
 - removing of doctests from modules

Moved from https://github.com/pyodide/pyodide/pull/3729. See the parent PR for more details.

TODO:
 - [x] add documentation 
 - [x] test the CLI endpoint