### PR TITLE
Pyodide 0.24.0 compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-  python: "3.10"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v4.4.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+### Added
+
  - Add `pyidide minify` command to minify the Python packages with AST rewrites by,
    removing comments and docstrings
    [#23](https://github.com/pyodide/pyodide-pack/pull/23)
+
+### Changed
+
+ - Added support for Pyodide 0.24.0. This is now the minimal supported version of Pyodide.
+   [#26](https://github.com/pyodide/pyodide-pack/pull/26)
 
 ## [0.2.0] - 2022-09-04
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ Pyodide-pack requires Python 3.10+ and can be installed via pip:
 pip install pyodide-pack
 ```
 
-(optionally) For elimation of unused modules via runtime detection, run NodeJS  needs to be installed,
-as well,
+(optionally) For elimation of unused modules via runtime detection, run NodeJS  needs to be installed together with Pyodide 0.24.0+:
 
 ```bash
-npm install pyodide
+npm install pyodide@">0.24.0"
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "pyodide": "^0.23.3"
+    "node-fetch": "^3.3.2",
+    "pyodide": "^0.24.0"
   }
 }

--- a/pyodide_pack/cli.py
+++ b/pyodide_pack/cli.py
@@ -83,7 +83,7 @@ def main(
         }
 
     package_dir = ROOT_DIR / "node_modules" / "pyodide"
-    with open(package_dir / "repodata.json") as fh:
+    with open(package_dir / "pyodide-lock.json") as fh:
         packages_json = json.load(fh)
 
     packages: dict[str, ArchiveFile] = {}

--- a/pyodide_pack/js/discovery.js
+++ b/pyodide_pack/js/discovery.js
@@ -1,9 +1,9 @@
 
 async function main() {
-  let pyodide_mod = await import("pyodide/pyodide.js");
+  const { loadPyodide } = require("pyodide");
   let fs = await import("fs");
 
-  let pyodide = await pyodide_mod.loadPyodide()
+  let pyodide = await loadPyodide()
   let file_list = [];
   const open_orig = pyodide._module.FS.open;
   // Monkeypatch FS.open

--- a/pyodide_pack/js/validate.js
+++ b/pyodide_pack/js/validate.js
@@ -2,13 +2,13 @@ var buff;
 
 
 async function main() {
-  let pyodide_mod = await import("pyodide/pyodide.js");
+  let { loadPyodide } = require("pyodide");
   let fs = await import("fs");
   let fetch = await import("node-fetch");
   let bench = new Object();
 
   let t0 = process.hrtime.bigint();
-  let pyodide = await pyodide_mod.loadPyodide({fullStdLib: false});
+  let pyodide = await loadPyodide({fullStdLib: false});
   bench.loadPyodide = Number(process.hrtime.bigint() - t0);
 
 


### PR DESCRIPTION
Adds fixes to make this package run with Pyodide 0.24.0. 

Also makes this version of Pyodide the only supported version, as it will not be practical to support older versions (in particular with respect to how the stdlib is shipped before 0.23)