### PR TITLE
Draft: Add support for stdlib bundling

### DIFF
--- a/examples/stdlib_only/app.py
+++ b/examples/stdlib_only/app.py
@@ -1,0 +1,3 @@
+import math
+
+math.sqrt(2)

--- a/pyodide_pack/cli.py
+++ b/pyodide_pack/cli.py
@@ -33,6 +33,11 @@ def main(
         "--include",
         help='One or multiple glob patterns separated by "," of extra files to include',
     ),
+    write_debug_map: bool = typer.Option(
+        False,
+        help="Write a debug map (to './debug-map.json') with all"
+        "the detected imports for the generated bundle",
+    ),
 ):  # type: ignore
     """Create a minimal bundle for a Pyodide application with the required dependencies
 
@@ -81,8 +86,11 @@ def main(
             for idx, path in enumerate(db["find_object_calls"])
             if path.endswith(".so")
         }
+    if write_debug_map:
+        Path("./debug-map.json").write_text(json.dumps(db, indent=2))
 
     package_dir = ROOT_DIR / "node_modules" / "pyodide"
+
     with open(package_dir / "pyodide-lock.json") as fh:
         packages_json = json.load(fh)
 
@@ -97,6 +105,14 @@ def main(
 
         packages[file_name] = ArchiveFile(package_dir / file_name, name=key)
 
+    stdlib_archive = ArchiveFile(package_dir / "python_stdlib.zip", name="stdlib")
+    stdlib_striped_path = Path("python_stdlib_stripped.zip")
+
+    console.print(
+        f"Using stdlib ({len(stdlib_archive.namelist())} files) with a total size "
+        f"of {stdlib_archive.total_size(compressed=True)/1e6:.2f} MB."
+    )
+
     packages_size = sum(el.total_size(compressed=False) for el in packages.values())
     packages_size_gzip = sum(el.total_size(compressed=True) for el in packages.values())
     console.print(
@@ -104,10 +120,16 @@ def main(
         f"total size of {packages_size_gzip/1e6:.2f} MB  "
         f"(uncompressed: {packages_size/1e6:.2f} MB)"
     )
+    if db["opened_file_names"]:
+        console.print(
+            f"In total {len(db['opened_file_names'])} files and "
+            f"{len(db['find_object_calls'])} dynamic libraries were accessed."
+        )
+    total_initial_size = packages_size_gzip + stdlib_archive.total_size(compressed=True)
     console.print(
-        f"In total {len(db['opened_file_names'])} files and {len(db['find_object_calls'])} "
-        "dynamic libraries were accessed.\n"
+        f"Total initial size (stdlib + dependencies): {total_initial_size/1e6:.2f} MB"
     )
+    console.print("\n")
 
     out_bundle_path = Path("./pyodide-package-bundle.zip")
 
@@ -123,6 +145,34 @@ def main(
     with zipfile.ZipFile(
         out_bundle_path, "w", compression=zipfile.ZIP_DEFLATED
     ) as fh_out, Live(table) as live:
+        with zipfile.ZipFile(
+            stdlib_striped_path, "w", compression=zipfile.ZIP_DEFLATED
+        ) as fh_stdlib_out:
+            # Find the prefix for one of the stdlib modules loaded from the zip files
+            stdlib_prefix = db["init_sys_modules"]["pathlib"].replace("/pathlib.py", "")
+            imported_paths = (
+                list(db["init_sys_modules"].values()) + db["opened_file_names"]
+            )
+            imported_paths = [
+                path.replace(stdlib_prefix + "/", "")
+                for path in imported_paths
+                if path.startswith(stdlib_prefix)
+            ]
+            for name in stdlib_archive.namelist():
+                if name in imported_paths:
+                    fh_stdlib_out.writestr(name, stdlib_archive.read(name))
+        stdlib_archive_stripped = ArchiveFile(stdlib_striped_path, name="stdlib")
+        msg_0 = "0"
+        msg_1 = "stdlib"
+        msg_2 = f"{len(stdlib_archive.namelist())} [red]→[/red] {len(stdlib_archive_stripped.namelist())}"
+        msg_3 = ""
+        msg_4 = (
+            f"{stdlib_archive.total_size(compressed=True) / 1e6:.2f} [red]→[/red] "
+            f"{stdlib_archive_stripped.total_size(compressed=True)/1e6:.2f}"
+        )
+        msg_5 = f"{100*(1 - stdlib_archive_stripped.total_size(compressed=True) / stdlib_archive.total_size(compressed=True)):.1f} %"
+        table.add_row(msg_0, msg_1, msg_2, msg_3, msg_4, msg_5)
+        live.refresh()
         for idx, ar in enumerate(sorted(packages.values(), key=lambda x: x.name)):
             # Sort keys for reproducibility
             in_file_names = sorted(ar.namelist())
@@ -212,10 +262,11 @@ def main(
             fh.write(loader_path.read_text().encode("utf-8"))
 
     out_bundle_size = out_bundle_path.stat().st_size
-    console.print(
-        f"Wrote {out_bundle_path} with {out_bundle_size/ 1e6:.2f} MB "
-        f"({100*(1 - out_bundle_size/packages_size_gzip):.1f}% reduction) \n"
-    )
+    if packages_size_gzip:
+        console.print(
+            f"Wrote {out_bundle_path} with {out_bundle_size/ 1e6:.2f} MB "
+            f"({100*(1 - out_bundle_size/packages_size_gzip):.1f}% reduction) \n"
+        )
 
     # We start a webserver so that the bundle can be loaded via fetch
     with spawn_web_server(dist_dir=".") as (_, port, server_logs):
@@ -241,6 +292,16 @@ def main(
         "[bold]100 %[/bold]",
     )
     console.print(table)
+
+    total_final_size = (
+        stdlib_archive_stripped.total_size(compressed=True) + out_bundle_size
+    )
+
+    console.print(
+        f"\nTotal output size (stdlib + packages): "
+        f"{total_final_size/1e6:.2f} MB "
+        f"({100*(1 - total_final_size/total_initial_size):.1f}% reduction)"
+    )
 
     console.print("\nBundle validation successful.")
 

--- a/pyodide_pack/js/validate.js
+++ b/pyodide_pack/js/validate.js
@@ -8,7 +8,7 @@ async function main() {
   let bench = new Object();
 
   let t0 = process.hrtime.bigint();
-  let pyodide = await loadPyodide({fullStdLib: false});
+  let pyodide = await loadPyodide({fullStdLib: false, stdLibURL: "http://127.0.0.1:{{ port }}/python_stdlib_striped.zip"});
   bench.loadPyodide = Number(process.hrtime.bigint() - t0);
 
 


### PR DESCRIPTION
Closes https://github.com/pyodide/pyodide-pack/issues/1

Adds an implementation of the stdlib bundling. In the end, not using any hooks https://github.com/pyodide/pyodide/pull/3664 but looking at `sys.modules` to know which stdlib modules were loaded and combine this information with the list of accessed files (after the `loadPyodide` initialization). File system level hooks are not working well with stdlib imported from a zip file otherwise.

This produces the `python_stdlib_striped.zip` file which can then be passed to `loadPyodide`.

On a few examples I tried this to reduce the stdlib size by around 3x, so it's a big change..

A  simple stdlib example that only uses the `math` module,
<details>

```
pyodide pack examples/stdlib_only/app.py --write-debug-map 
Running pyodide pack on examples/stdlib_only/app.py

Note: unless otherwise specified all sizes are given for gzip compressed files to be representative of CDN compression.

Loaded requirements from: examples/stdlib_only/requirements.txt
Running the input code in Node.js to detect used modules..

No new packages to load

Done input code execution in 1.4 s

Using stdlib (547 files) with a total size of 2.25 MB.
Detected 0 dependencies with a total size of 0.00 MB  (uncompressed: 0.00 MB)
Total initial size (stdlib + dependencies): 2.25 MB


                            Packing..                            
┏━━━━┳━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ No ┃ Package ┃ All files ┃ .so libs ┃   Size (MB) ┃ Reduction ┃
┡━━━━╇━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│  0 │ stdlib  │ 547 → 152 │          │ 2.25 → 0.75 │    66.6 % │
└────┴─────────┴───────────┴──────────┴─────────────┴───────────┘
Spawning webserver at http://127.0.0.1:43095 (see logs in /tmp/tmp1swqnxzd/http-server.log)
Running the input code in Node.js to validate bundle..

        Validating and benchmarking the output bundle..         
┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Step                 ┃ Load time (s) ┃ Fraction of load time ┃
┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━┩
│ loadPyodide          │          1.27 │                96.0 % │
│ fetch_unpack_archive │          0.05 │                 3.6 % │
│ load_dynamic_libs    │          0.00 │                 0.3 % │
│ import_run_app       │          0.00 │                 0.2 % │
│ TOTAL                │          1.33 │                 100 % │
└──────────────────────┴───────────────┴───────────────────────┘

Total output size (stdlib + packages): 0.75 MB (66.6% reduction)
```

</details>

 