### PR TITLE
pyodide pack: Add support for packages installed with micropip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Add support for stdlib bundling in `pyodide pack`
    [#27](https://github.com/pyodide/pyodide-pack/pull/27)
 
+ - Add support for packages installed via micropip in `pyodide pack`
+   [#31](https://github.com/pyodide/pyodide-pack/pull/31)
+
 
 ### Changed
 

--- a/examples/micropip_deps/app.py
+++ b/examples/micropip_deps/app.py
@@ -1,0 +1,6 @@
+# Examples of a package that is installed by micropip from PyPI
+
+import snowballstemmer
+
+stemmer = snowballstemmer.stemmer("english")
+print(stemmer.stemWords("An example of stemming".split()))

--- a/examples/micropip_deps/requirements.txt
+++ b/examples/micropip_deps/requirements.txt
@@ -1,0 +1,1 @@
+snowballstemmer

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -46,6 +46,15 @@ def test_all(example_dir, tmp_path):
 
     stdout_str = stdout.getvalue()
     assert "Bundle validation successful" in stdout_str
+    using_micropip = (
+        "Failed to load packages with loadPackage, re-trying with micropip."
+        in stdout_str
+    )
+
+    if example_dir.name == ["micropip_deps"]:
+        assert using_micropip
+    else:
+        assert not using_micropip
     assert (tmp_path / "python_stdlib_stripped.zip").exists()
     # Better than 20% size reduction on the stdlib
     assert (tmp_path / "python_stdlib_stripped.zip").stat().st_size < (

--- a/pyodide_pack/_utils.py
+++ b/pyodide_pack/_utils.py
@@ -121,6 +121,7 @@ def _get_packages_from_lockfile(
         elif val == "pypi":
             url = pyodide_lock.packages[key].file_name
             file_name = os.path.basename(url)
+            # Cache wheels in node_modules/pyodide
             # Will raise an exception if the URL is not valid
             with urllib.request.urlopen(url) as response:
                 (package_dir / file_name).write_bytes(response.read())

--- a/pyodide_pack/_utils.py
+++ b/pyodide_pack/_utils.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import sys
 import tempfile
+import urllib.request
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -117,6 +118,12 @@ def _get_packages_from_lockfile(
     for key, val in loaded_packages.items():
         if val == "default channel":
             file_name = pyodide_lock.packages[key].file_name
+        elif val == "pypi":
+            url = pyodide_lock.packages[key].file_name
+            file_name = os.path.basename(url)
+            # Will raise an exception if the URL is not valid
+            with urllib.request.urlopen(url) as response:
+                (package_dir / file_name).write_bytes(response.read())
         else:
             # Otherwise loaded from custom URL
             # TODO: this branch needs testing

--- a/pyodide_pack/cli.py
+++ b/pyodide_pack/cli.py
@@ -89,7 +89,10 @@ def main(
 
     package_dir = ROOT_DIR / "node_modules" / "pyodide"
 
-    pyodide_lock = PyodideLockSpec.from_json(package_dir / "pyodide-lock.json")
+    if "pyodide_lock" in db:
+        pyodide_lock = PyodideLockSpec(**json.loads(db["pyodide_lock"]))
+    else:
+        pyodide_lock = PyodideLockSpec.from_json(package_dir / "pyodide-lock.json")
 
     packages = _get_packages_from_lockfile(
         pyodide_lock, db["loaded_packages"], package_dir

--- a/pyodide_pack/js/discovery.js
+++ b/pyodide_pack/js/discovery.js
@@ -22,7 +22,7 @@ async function main() {
   try {
   	await pyodide.loadPackage({{packages}});
   } catch (e) {
-	console.log("Failed to load packages, trying to load micropip");
+	console.log("Failed to load packages with loadPackage, re-trying with micropip.");
 	await pyodide.loadPackage("micropip");
 	let micropip = pyodide.pyimport("micropip");
 	await micropip.install({{packages}});

--- a/pyodide_pack/js/discovery.js
+++ b/pyodide_pack/js/discovery.js
@@ -19,7 +19,14 @@ async function main() {
     return open_orig(path, flags, mode, fd_start, fd_end);
   };
 
-  await pyodide.loadPackage({{packages}});
+  try {
+  	await pyodide.loadPackage({{packages}});
+  } catch (e) {
+	console.log("Failed to load packages, trying to load micropip");
+	await pyodide.loadPackage("micropip");
+	let micropip = pyodide.pyimport("micropip");
+	await micropip.install({{packages}});
+  }
 
   // Monkeypatching findObject calls used in dlopen
   let findObjectCalls = [];
@@ -42,6 +49,9 @@ async function main() {
   obj.loaded_packages = pyodide.loadedPackages;
   obj.find_object_calls = findObjectCalls;
   obj.sys_modules = sysModules;
+  if ("micropip" in pyodide.loadedPackages) {
+    obj.pyodide_lock = pyodide.pyimport("micropip").freeze();
+  }
   // For some reason there is a double / in the path
   obj.stdlib_prefix = pyodide.pyimport('sysconfig').get_path('stdlib').replace('//', '/');
   let jsonString = JSON.stringify(obj);


### PR DESCRIPTION
Closes https://github.com/pyodide/pyodide-pack/issues/4

The added logic is,
 1. Try installing dependencies with `loadPackage`. If it fails, fallback to `micropip`
 2. If micropip is installed, at the end of the application run, call `micropip.freeze()` and use the output as the new lockfile for finding the install URL of wheels downloaded from PyPI
 3. Download PyPI wheels to `node_modules/pyodide` alongside wheels  downloaded by `loadPackage`. This is maybe a non-optimal side effect of running `pyodide pack` but we should do PyPI wheel caching in node in any case.
 
 This means however that micropip + packaging get budled unnecessarily. For now, given their relatively small size I will keep them.
 
 Example of running `pyodide pack examples/micropip_deps/app.py`
 ```
 ┏━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ No ┃ Package                        ┃ All files ┃ .so libs ┃   Size (MB) ┃ Reduction ┃
┡━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│  0 │ stdlib                         │ 547 → 161 │          │ 2.25 → 0.82 │    63.6 % │
│  1 │ micropip-0.4.0-py3-none-any.w… │   33 → 28 │    0 → 0 │ 0.05 → 0.04 │    17.7 % │
│  2 │ packaging-23.1-py3-none-any.w… │   21 → 14 │    0 → 0 │ 0.05 → 0.04 │    24.1 % │
│  3 │ snowballstemmer-2.2.0-py2.py3… │   37 → 34 │    0 → 0 │ 0.08 → 0.08 │     3.2 % │
└────┴────────────────────────────────┴───────────┴──────────┴─────────────┴───────────┘
Wrote pyodide-package-bundle.zip with 0.17 MB (2.2% reduction)
[...]
Total output size (stdlib + packages): 0.99 MB (59.2% reduction)
```
 