### PR TITLE
Fix bundling of .so files

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -12,16 +12,7 @@ def gen_all_examples():
     for path in Path("examples").glob("*"):
         if path.is_dir() and (path / "requirements.txt").exists():
             path = path.resolve()
-            if path.name in ["scikit-learn", "scipy"]:
-                yield pytest.param(
-                    path,
-                    marks=pytest.mark.xfail(
-                        reason="Known issue with .so loading in scipy"
-                    ),
-                    id=path.name,
-                )
-            else:
-                yield pytest.param(path, id=path.name)
+            yield pytest.param(path, id=path.name)
 
 
 BASE_DIR = Path(__file__).parents[1]

--- a/pyodide_pack/_utils.py
+++ b/pyodide_pack/_utils.py
@@ -45,7 +45,7 @@ def match_suffix(file_paths: list[str], suffix: str) -> str | None:
 # Adapted from pyodide conftest.py
 
 
-def run_web_server(q, log_filepath, dist_dir):
+def run_web_server(q: multiprocessing.Queue, log_filepath, dist_dir):
     """Start the HTTP web server
 
     Parameters
@@ -79,7 +79,7 @@ def run_web_server(q, log_filepath, dist_dir):
 
     with socketserver.TCPServer(("", 0), Handler) as httpd:
         host, port = httpd.server_address
-        print(f"Starting webserver at http://{host}:{port}")
+        print(f"Starting webserver at http://{host}:{port}")  # type: ignore[str-bytes-safe]
         httpd.server_name = "test-server"  # type: ignore[attr-defined]
         httpd.server_port = port  # type: ignore[attr-defined]
         q.put(port)
@@ -88,7 +88,7 @@ def run_web_server(q, log_filepath, dist_dir):
 
 
 @contextmanager
-def spawn_web_server(dist_dir):
+def spawn_web_server(dist_dir: str):
     tmp_dir = tempfile.mkdtemp()
     log_path = Path(tmp_dir) / "http-server.log"
     q: multiprocessing.Queue[str] = multiprocessing.Queue()

--- a/pyodide_pack/cli.py
+++ b/pyodide_pack/cli.py
@@ -185,7 +185,6 @@ def main(
                     # also determine if it's a shared library or not from
                     # the given package
                     dll = db["dynamic_libs_map"][out_file_name]
-                    dll.shared = pyodide_lock.packages[ar.name].sharedlibrary
                     dynamic_libs.append(dll)
 
                 if (
@@ -207,7 +206,6 @@ def main(
                             stats["so_out"] += 1
                             # Manually included dynamic libraries are going to be loaded first
                             dll = DynamicLib(out_file_name, load_order=-1000)
-                            dll.shared = pyodide_lock.packages[ar.name].sharedlibrary
                             dynamic_libs.append(dll)
 
                 if out_file_name is not None:

--- a/pyodide_pack/cli.py
+++ b/pyodide_pack/cli.py
@@ -140,11 +140,7 @@ def main(
     ) as fh_out, Live(table) as live:
         imported_paths = db.get_imported_paths(strip_prefix=db.stdlib_prefix)
         stdlib_archive_stripped = stdlib_archive.filter_to_zip(
-            stdlib_stripped_path,
-            # Include imported stdlib modules and all pyodide modules
-            # Some modules are used when loading the bundle (e.g. json)
-            func=lambda name: name in imported_paths
-            or any(prefix in name for prefix in ["pyodide", "json", "cp437"]),
+            stdlib_stripped_path, func=lambda name: name in imported_paths
         )
 
         msg_0 = "0"

--- a/pyodide_pack/js/discovery.js
+++ b/pyodide_pack/js/discovery.js
@@ -38,6 +38,10 @@ async function main() {
   await pyodide.runPythonAsync(`
 {{ code }}
 `);
+  // Run code used in the loader
+  await pyodide.runPythonAsync(`
+import pyodide.http
+`);
   // Look for loaded modules. That's the only way to access imported stdlib from the zipfile.
   let sysModules = pyodide.runPython(
 	"import sys; {name: getattr(mod, '__file__', None) for name, mod in sys.modules.items()}"

--- a/pyodide_pack/js/discovery.js
+++ b/pyodide_pack/js/discovery.js
@@ -1,32 +1,94 @@
+function patchFSopen(pyodide, fileList) {
+  // Record FS.open
+  // Note: we can't use FS.trackingDelegate since we want this to work without
+  // -sFS_DEBUG
+  const openOrig = pyodide._module.FS.open;
+  pyodide._module.FS.open = function (path, flags, mode, fd_start, fd_end) {
+    // Read-only flag is even
+    // https://github.com/emscripten-core/emscripten/blob/e8f25f84933a7973ad1a4e32084a8bf169d67d35/tests/fs/test_trackingdelegate.c#L18
+    // Here we only keep files in read mode.
+    if (flags % 2 == 0) {
+      fileList.push(path);
+    }
+    return openOrig(path, flags, mode, fd_start, fd_end);
+  };
+}
+
+
+function pathchLoadDynLib(pyodide, loadDynlibCalls) {
+  // Record loadDynlib calls
+  const loadDynlibOrig = pyodide._module.loadDynamicLibrary;
+  pyodide._module.loadDynamicLibrary = function(libName, flags, localScope, handle) {
+	loadDynlibCalls.push({path: libName, global: flags.global});
+	return loadDynlibOrig(libName, flags, localScope, handle)
+  }
+}
+
+
+function patchSymbolAccess(pyodide, accessedSymbols) {
+  // Record accessed symbols in pyodide._module.LDSO
+  function wrapSym(symName, sym, libName) {
+    if (!sym || typeof sym == "number") {
+      return sym;
+    }
+    return new Proxy(sym, {
+      get(sym, attr) {
+        if (attr === "stub") {
+          if (!(libName in accessedSymbols)) {
+            accessedSymbols[libName] = new Set();
+          }
+          accessedSymbols[libName].add(symName);
+        }
+        return Reflect.get(sym, attr);
+      },
+    });
+  }
+
+  function wrapExports(exports, libName) {
+    if (typeof exports !== "object") {
+      return exports;
+    }
+    return new Proxy(exports, {
+      get(exports, symName) {
+        const sym = Reflect.get(exports, symName);
+        if (libName in accessedSymbols &&  accessedSymbols[libName].has(symName)) {
+          return sym;
+        }
+        return wrapSym(symName, sym, libName);
+      },
+    });
+  }
+
+  function wrapLib(lib, libName) {
+    return new Proxy(lib, {
+      get(lib, sym) {
+        return wrapExports(Reflect.get(lib, sym), libName);
+      },
+    });
+  }
+  origLoadedlibs = pyodide._module.LDSO.loadedLibsByName;
+  pyodide._module.LDSO.loadedLibsByName = new Proxy(origLoadedlibs, {
+    set(libsByName, libName, lib) {
+      return Reflect.set(libsByName, libName, wrapLib(lib, libName));
+    },
+  });
+}
+
 
 async function main() {
   const { loadPyodide } = require("pyodide");
   let fs = await import("fs");
 
   let pyodide = await loadPyodide()
-  let file_list = [];
-  const open_orig = pyodide._module.FS.open;
-  // Monkeypatch FS.open
-  // Note: we can't use FS.trackingDelegate since we want this to work without
-  // -sFS_DEBUG
-  pyodide._module.FS.open = function (path, flags, mode, fd_start, fd_end) {
-    // Read-only flag is even
-    // https://github.com/emscripten-core/emscripten/blob/e8f25f84933a7973ad1a4e32084a8bf169d67d35/tests/fs/test_trackingdelegate.c#L18
-    // Here we only keep files in read mode.
-    if (flags % 2 == 0) {
-      file_list.push(path);
-    }
-    return open_orig(path, flags, mode, fd_start, fd_end);
-  };
+  let fileList = [];
+  patchFSopen(pyodide, fileList);
 
-  // Monkeypatching findObject calls used in dlopen
   let loadDynlibCalls = [];
-  const loadDynlib_orig = pyodide._api.loadDynlib;
-  pyodide._api.loadDynlib = function(path, global) {
-	console.error("loadDynlib", path, global);
-	loadDynlibCalls.push({"path": path, "global": global});
-	return loadDynlib_orig(path, dontResolveLastLink);
-  }
+  pathchLoadDynLib(pyodide, loadDynlibCalls);
+
+  var accessedSymbols = new Object();
+  patchSymbolAccess(pyodide, accessedSymbols);
+
 
   try {
   	await pyodide.loadPackage({{packages}});
@@ -49,13 +111,20 @@ import pyodide.http
 	"import sys; {name: getattr(mod, '__file__', None) for name, mod in sys.modules.items()}"
   ).toJs({dict_converter : Object.fromEntries});
 
+  // Convert accessedSymbols to from Set to Array, so it can be serialized
+  accessedSymbolsOut = new Object();
+  for (const libName in accessedSymbols) {
+     accessedSymbolsOut[libName] = Array.from(accessedSymbols[libName]);
+  }
+
   // writing the list of accessed files to disk
   var obj = {
-	opened_file_names: file_list,
+	opened_file_names: fileList,
 	loaded_packages: pyodide.loadedPackages,
 	load_dyn_lib_calls: loadDynlibCalls,
 	sys_modules: sysModules,
 	LDSO_loaded_libs_by_handle: pyodide._module.LDSO['loadedLibsByHandle'],
+	dl_accessed_symbols: accessedSymbolsOut,
   };
   if ("micropip" in pyodide.loadedPackages) {
     obj.pyodide_lock = pyodide.pyimport("micropip").freeze();

--- a/pyodide_pack/loader/pyodide_pack_loader.py
+++ b/pyodide_pack/loader/pyodide_pack_loader.py
@@ -7,4 +7,5 @@ async def setup():
 
     for paths in Path("/bundle-so-list.txt").read_text().splitlines():
         path, is_shared = paths.split(",")
+        print(f"Loading {path} as {'shared' if is_shared else 'static'}")
         await _module.API.loadDynlib(path, bool(is_shared))

--- a/pyodide_pack/loader/pyodide_pack_loader.py
+++ b/pyodide_pack/loader/pyodide_pack_loader.py
@@ -7,4 +7,4 @@ async def setup():
 
     for paths in Path("/bundle-so-list.txt").read_text().splitlines():
         path, is_shared = paths.split(",")
-        await _module._api.loadDynlib(path, bool(is_shared))
+        await _module.API.loadDynlib(path, bool(is_shared))

--- a/pyodide_pack/loader/pyodide_pack_loader.py
+++ b/pyodide_pack/loader/pyodide_pack_loader.py
@@ -7,5 +7,4 @@ async def setup():
 
     for paths in Path("/bundle-so-list.txt").read_text().splitlines():
         path, is_shared = paths.split(",")
-        print(f"Loading {path} as {'shared' if is_shared else 'static'}")
         await _module.API.loadDynlib(path, bool(is_shared))

--- a/pyodide_pack/runtime_detection.py
+++ b/pyodide_pack/runtime_detection.py
@@ -72,7 +72,10 @@ class RuntimeResults(dict):
                 obj["path"], shared=obj.get("global", False), load_order=idx
             )
             for idx, obj in enumerate(db["load_dyn_lib_calls"])
-            if obj["path"].endswith(".so") and obj["path"] in db["dl_accessed_symbols"]
+            # Include locally loaded .so by they shared symbols
+            # or if they are globally loaded
+            if obj["path"].endswith(".so")
+            and ((obj["path"] in db["dl_accessed_symbols"]) or obj["global"])
         }
         return db
 
@@ -116,12 +119,13 @@ class PackageBundler:
 
         out_file_name = None
         if out_file_name := match_suffix(
-            list(db["dl_accessed_symbols"].keys()), in_file_name
+            list(db["dynamic_libs_map"].keys()), in_file_name
         ):
             stats["so_out"] += 1
             # Get the dynamic library path while preserving order
             dll = db["dynamic_libs_map"][out_file_name]
             self.dynamic_libs.append(dll)
+
         elif out_file_name := match_suffix(db["opened_file_names"], in_file_name):
             match extension:
                 case ".so":

--- a/pyodide_pack/runtime_detection.py
+++ b/pyodide_pack/runtime_detection.py
@@ -60,8 +60,10 @@ class RuntimeResults(dict):
         db["opened_file_names"] = list(dict.fromkeys(db["opened_file_names"]))
 
         db["dynamic_libs_map"] = {
-            path: DynamicLib(path, load_order=idx)
-            for idx, path in enumerate(db["find_object_calls"])
+            path: DynamicLib(
+                obj["path"], shared=obj.get("global", False), load_order=idx
+            )
+            for idx, obj in enumerate(db["load_dyn_lib_calls"])
             if path.endswith(".so")
         }
         return db

--- a/pyodide_pack/runtime_detection.py
+++ b/pyodide_pack/runtime_detection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from pyodide_pack.dynamic_lib import DynamicLib
 
@@ -60,10 +61,15 @@ class RuntimeResults(dict):
         db["opened_file_names"] = list(dict.fromkeys(db["opened_file_names"]))
 
         db["dynamic_libs_map"] = {
-            path: DynamicLib(
+            obj["path"]: DynamicLib(
                 obj["path"], shared=obj.get("global", False), load_order=idx
             )
             for idx, obj in enumerate(db["load_dyn_lib_calls"])
-            if path.endswith(".so")
+            if obj["path"].endswith(".so") and obj["path"] in db["dl_accessed_symbols"]
         }
         return db
+
+    def to_json(self, path: Path) -> None:
+        """Save the results.json with runtime execution information."""
+        with open(path, "w") as fh:
+            json.dump(self, fh, indent=2, default=vars)

--- a/pyodide_pack/runtime_detection.py
+++ b/pyodide_pack/runtime_detection.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import fnmatch
+import gzip
 import json
+import os
 from pathlib import Path
 
+from pyodide_pack._utils import (
+    match_suffix,
+)
+from pyodide_pack.archive import ArchiveFile
 from pyodide_pack.dynamic_lib import DynamicLib
 
 
@@ -73,3 +80,77 @@ class RuntimeResults(dict):
         """Save the results.json with runtime execution information."""
         with open(path, "w") as fh:
             json.dump(self, fh, indent=2, default=vars)
+
+
+class PackageBundler:
+    """Only include necessary files for a given package."""
+
+    def __init__(self, db: RuntimeResults, include_paths: str | None = None):
+        self.db = db
+        self.stats = {
+            "py_in": 0,
+            "so_in": 0,
+            "py_out": 0,
+            "so_out": 0,
+            "fh_out": 0,
+            "size_out": 0,
+            "size_gzip_out": 0,
+        }
+        self.dynamic_libs: list[DynamicLib] = []
+        self.include_paths = include_paths
+
+    def process_path(self, in_file_name: str) -> str | None:
+        """Process a path, returning the output path if it should be included."""
+        db = self.db
+        stats = self.stats
+        match Path(in_file_name).suffix:
+            case ".py":
+                stats["py_in"] += 1
+            case ".so":
+                stats["so_in"] += 1
+
+        out_file_name = None
+        if out_file_name := match_suffix(
+            list(db["dl_accessed_symbols"].keys()), in_file_name
+        ):
+            stats["so_out"] += 1
+            # Get the dynamic library path while preserving order
+            dll = db["dynamic_libs_map"][out_file_name]
+            self.dynamic_libs.append(dll)
+        elif out_file_name := match_suffix(db["opened_file_names"], in_file_name):
+            stats["py_out"] += 1
+
+        elif self.include_paths is not None and any(
+            fnmatch.fnmatch(in_file_name, pattern)
+            for pattern in self.include_paths.split(",")
+        ):
+            # TODO: this is hack and should be done better
+            out_file_name = os.path.join("/lib/python3.11/site-utils", in_file_name)
+            match Path(in_file_name).suffix:
+                case ".py":
+                    stats["py_out"] += 1
+                case ".so":
+                    stats["so_out"] += 1
+                    # Manually included dynamic libraries are going to be loaded first
+                    dll = DynamicLib(out_file_name, load_order=-1000)
+                    self.dynamic_libs.append(dll)
+        return out_file_name
+
+    def copy_between_zip_files(
+        self,
+        in_file_name: str,
+        out_file_name: str,
+        archive: ArchiveFile,
+        fh_out,
+    ) -> None:
+        """Copy a file between two archives."""
+        stats = self.stats
+        stats["fh_out"] += 1
+        stream = archive.read(in_file_name)
+        if stream is not None:
+            stats["size_out"] += len(stream)
+            stats["size_gzip_out"] += len(gzip.compress(stream))
+            # File paths starting with / fails to get correctly extracted
+            # in extract_archive in Pyodide
+            with fh_out.open(out_file_name.lstrip("/"), "w") as fh:
+                fh.write(stream)

--- a/pyodide_pack/tests/test_runtime_detection.py
+++ b/pyodide_pack/tests/test_runtime_detection.py
@@ -1,13 +1,18 @@
 import json
 
 from pyodide_pack.dynamic_lib import DynamicLib
-from pyodide_pack.runtime_detection import RuntimeResults
+from pyodide_pack.runtime_detection import PackageBundler, RuntimeResults
 
 
 def test_runtime_results(tmp_path):
     input_data = {
         "opened_file_names": ["a.py", "b.py", "__pycache__/a.cpython-38.pyc"],
-        "find_object_calls": ["c.so"],
+        "load_dyn_lib_calls": [
+            {"path": "c.so", "global": False},
+            {"path": "d.so", "global": False},
+            {"path": "g.so", "global": True},
+        ],
+        "dl_accessed_symbols": {"c.so": None},
     }
 
     with open(tmp_path / "results.json", "w") as fh:
@@ -16,11 +21,30 @@ def test_runtime_results(tmp_path):
     res = RuntimeResults.from_json(tmp_path / "results.json")
     assert list(res.keys()) == [
         "opened_file_names",
-        "find_object_calls",
+        "load_dyn_lib_calls",
+        "dl_accessed_symbols",
         "dynamic_libs_map",
     ]
 
     assert res["opened_file_names"] == ["a.py", "b.py"]
+    # d.so not included as it's not in accessed LDSO symbols
+    # g.so is include as it's globally loaded
     assert res["dynamic_libs_map"] == {
-        "c.so": DynamicLib(path="c.so", load_order=0, shared=False)
+        "c.so": DynamicLib(path="c.so", load_order=0, shared=False),
+        "g.so": DynamicLib(path="g.so", load_order=2, shared=True),
     }
+
+
+def test_bundler_process_path(tmp_path):
+    db = RuntimeResults(
+        opened_file_names=["a.py", "d/b.py", "d/f.so", "c.so"],
+        dynamic_libs_map={
+            "d/f.so": DynamicLib(path="d/f.so", load_order=0, shared=False)
+        },
+    )
+    bundler = PackageBundler(db)
+
+    assert bundler.process_path("k.py") is None
+    assert bundler.process_path("a.py") == "a.py"
+    assert bundler.process_path("b.py") == "d/b.py"
+    assert bundler.process_path("f.so") == "d/f.so"


### PR DESCRIPTION
This fixes the bundling of .so files that got broken once pyodide switched to using [`loadDynlib`](https://github.com/pyodide/pyodide/blob/fb9417ffe592a18b5c018d5104e52a0d1a34feaf/src/js/dynload.ts#L95), previously we were hooking into emscripten's `FS.findObject` but this no longer works with recent pyodide versions.

The logic added here is,
 1. store the list of all locally accessed symbols (LDSO) when running the application in the sandbox (thanks to Hood's suggestion in https://github.com/pyodide/pyodide-pack/issues/32)
 2. monekypatch loadDynamicLibrary to know the order in which .so files were loaded (so we can preserve it).
    - Note that monkeypatching pyodide's loadDynlib to record the arguments with which it was called doesn't work. This means that I currently don't record [`searchDirs`](https://github.com/pyodide/pyodide/blob/fb9417ffe592a18b5c018d5104e52a0d1a34feaf/src/js/dynload.ts#L98C3-L98C13) passed to `loadDynlib`. It's a known issue that should be fixed later. At least this PR fixes the scipy example, so it's already an improvement.
 3. when deciding whether to include an .so, include those that,
   - have symbols that were accessed
   - or are globally loaded. We could do a more fine-grained inclusion for globally loaded dynamic libraries later.
 4. Finally, load the .so with `loadDynlib` in the same order. 
    - currently I'm nor caching the `FS.readFile`  as we are doing [in Pyodide](https://github.com/pyodide/pyodide/blob/fb9417ffe592a18b5c018d5104e52a0d1a34feaf/src/js/dynload.ts#L168) as I'm not sure how much it matters, but maybe I should.
 
 
 With the scipy example,
 ```
 $ pyodide pack examples/scikit-learn/app.py --write-debug-map

 Detected 7 dependencies with a total size of 22.47 MB  (uncompressed: 79.21 MB)
Total initial size (stdlib + dependencies): 24.72 MB


                                        Packing..                                        
┏━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ No ┃ Package                        ┃ All files ┃ .so libs ┃    Size (MB) ┃ Reduction ┃
┡━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│  0 │ stdlib                         │ 547 → 180 │          │  2.25 → 0.98 │    56.4 % │
│  1 │ distutils-1.0.0.zip            │    53 → 0 │    0 → 0 │  0.18 → 0.00 │   100.0 % │
│  2 │ joblib-1.3.2-py3-none-any.whl  │   52 → 17 │    0 → 0 │  0.17 → 0.08 │    53.9 % │
│  3 │ numpy-1.25.2-cp311-cp311-emsc… │ 430 → 111 │  19 → 14 │  3.06 → 2.36 │    22.8 % │
│  4 │ openblas-0.3.23.zip            │     1 → 1 │    1 → 1 │  1.84 → 1.84 │     0.0 % │
│  5 │ scikit_learn-1.3.0-cp311-cp31… │ 383 → 167 │  68 → 42 │  5.43 → 3.02 │    44.3 % │
│  6 │ scipy-1.11.1-cp311-cp311-emsc… │ 708 → 430 │ 118 → 89 │ 11.77 → 7.82 │    33.5 % │
│  7 │ threadpoolctl-3.2.0-py3-none-… │     5 → 1 │    0 → 0 │  0.01 → 0.01 │    31.2 % │
└────┴────────────────────────────────┴───────────┴──────────┴──────────────┴───────────┘
[...]

Total output size (stdlib + packages): 16.35 MB (33.9% reduction)
```

It's not too bad but also not exceptional. The next step would be to strip .so of unused symbols (though that requires good coverage in the sample code).  In particular, this example is a random forest example and I think it doesn't need any of the BLAS functions (and likely very little from scipy).

cc @ryanking13 