### PR TITLE
Remove Mypy `# type: ignore[call-arg]` and remove deprecated `Extra.` fields from `Config` classes

### DIFF
--- a/pyodide_pack/ast_rewrite.py
+++ b/pyodide_pack/ast_rewrite.py
@@ -93,13 +93,14 @@ def main(
     input_dir: Path = typer.Argument(..., help="Path to the folder to compress"),
     strip_docstrings: bool = typer.Option(False, help="Strip docstrings"),
     strip_module_docstrings: bool = typer.Option(
-        False, help="Strip module lebel docstrings"
+        False, help="Strip module level docstrings"
     ),
     # py_compile: bool = typer.Option(False, help="py-compile files")
 ) -> None:
     """Minify a folder of Python files.
 
-    Note: this API will change before the next release
+    Note: this API will change before the next release.
+
     """
     output_dirname = input_dir.name + "_stripped"
     py_config = PyPackConfig(

--- a/pyodide_pack/config.py
+++ b/pyodide_pack/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel, ConfigDict
 
 try:
     import tomllib
@@ -39,22 +39,28 @@ def _get_config_section(path: Path) -> dict[str, Any] | None:
     return None
 
 
-class PyPackConfig(BaseModel, extra=Extra.forbid):  # type: ignore[call-arg]
+class PyPackConfig(BaseModel):
     """Configuration for handling Python files"""
+
+    model_config = ConfigDict(extra="forbid")
 
     strip_module_docstrings: bool = True
     strip_docstrings: bool = True
     py_compile: bool = False
 
 
-class SoPackConfig(BaseModel, extra=Extra.forbid):  # type: ignore[call-arg]
+class SoPackConfig(BaseModel):
     """Configuration for handling shared libraries"""
+
+    model_config = ConfigDict(extra="forbid")
 
     drop_unused_so: bool = True
 
 
-class PackConfig(BaseModel, extra=Extra.forbid):  # type: ignore[call-arg]
+class PackConfig(BaseModel):
     """pyodide-pack configuration"""
+
+    model_config = ConfigDict(extra="forbid")
 
     requires: list[str] = []
     include_paths: list[str] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ testpaths = [
 ]
 
 [tool.ruff]
-select = [
+lint.select = [
   "B904",   # bugbear (Within an except clause, raise exceptions with raise ... from err)
   "B905",   # bugbear (zip() without an explicit strict= parameter set.)
 #  "C9",     # mccabe complexity
@@ -86,5 +86,5 @@ select = [
   "PLE",    # pylint errors
   "UP",     # pyupgrade
 ]
-ignore = ["E402", "E501", "E731", "E741"]
+lint.ignore = ["E402", "E501", "E731", "E741"]
 target-version = "py310"


### PR DESCRIPTION
and some miscellaneous updates (`ruff` uses `lint.` for its rules in `pyproject.toml`; a typo; and use of deprecated Pydantic APIs).