### PR TITLE
Migrate to `hatch`/`hatchling` + `hatch-vcs`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,20 +14,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.10"
+
       - name: Install dependencies
         run: |
           pip install -e ".[dev]"
 
-      - name: Test package without examples (no node required)
+      - name: Test package without examples (no Node required)
         run: |
           pytest pyodide_pack/
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: "20.6.1"
 
@@ -37,9 +43,10 @@ jobs:
 
       - name: Test package + examples
         run: |
-          pytest --cov=. -n 2 --cov-report=xml
+          pytest --cov=pyodide_pack -n 2 --cov-report=xml
+
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -48,18 +55,24 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     environment: PyPi-deploy
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: 3.10.2
+
       - name: Install requirements and build wheel
         shell: bash -l {0}
         run: |
           python -m pip install build twine
           python -m build .
+
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ _build/
 dist/
 .hypothesis
 build/
+venv
+.venv
+.DS_Store

--- a/pyodide_pack/__init__.py
+++ b/pyodide_pack/__init__.py
@@ -1,6 +1,3 @@
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import version
 
-try:
-    __version__ = version("pyodide-bundler")
-except PackageNotFoundError:
-    pass
+__version__ = version("pyodide_pack")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,9 @@ file = "README.md"
 content-type = "text/markdown"
 
 [project.urls]
-Homepage = "https://github.com/rth/pyodide-bundler"
-"Bug Tracker" = "https://github.com/rth/pyodide-bundler"
+Homepage = "https://github.com/pyodide/pyodide-pack/"
+"Bug Tracker" = "https://github.com/pyodide-pack/pyodide-pack/"
+Documentation = "https://pyodide-pack.pyodide.org/"
 
 [project.entry-points."pyodide.cli"]
 pack = "pyodide_pack.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
-requires = ["setuptools>=61.2", "setuptools_scm>=6.2"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
 
 [project]
 name = "pyodide-pack"
@@ -29,7 +32,6 @@ Homepage = "https://github.com/rth/pyodide-bundler"
 "Bug Tracker" = "https://github.com/rth/pyodide-bundler"
 
 [project.entry-points."pyodide.cli"]
-
 pack = "pyodide_pack.cli:main"
 minify = "pyodide_pack.ast_rewrite:main"
 
@@ -41,17 +43,6 @@ dev = [
     "hypothesis",
     "tomli-w"
 ]
-
-[tool.setuptools]
-package-dir = {"" = "."}
-include-package-data = false
-
-[tool.setuptools.packages.find]
-where = ["."]
-namespaces = false
-
-
-[tool.setuptools_scm]
 
 [tool.isort]
 profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-from setuptools import setup
-
-if __name__ == "__main__":
-    setup()


### PR DESCRIPTION
# Description

Closes #43

- drops `setup.py` and `setuptools` config, in favour of `hatchling`
- uses `fetch-depth` of 0 with actions/checkout to correctly perceive tags (plus pins all GitHub Actions for security),
- adds `__version__` from `importlib.metadata.version()` (which in-turn comes from `hatch-vcs`),
- updates outdated Homepage, "Bug Tracker" URLs, adds "Documentation" URL